### PR TITLE
Fix comment typo for \parencite{}

### DIFF
--- a/Theses/BScThesis.tex
+++ b/Theses/BScThesis.tex
@@ -10,7 +10,7 @@ norsk,  % comment for english version
 \usepackage[style=ieee, sorting=none]{biblatex}
 %%% If you want to use "author-year" style
 %%% where `\cite{Foo2011}` generates "Foo et al. (2011)"
-%%% and   `\parentcite{Foo2011}` generates "(Foo et al. 2011)"
+%%% and   `\parencite{Foo2011}` generates "(Foo et al. 2011)"
 %%% then comment the line above and use
 %\usepackage[style=authoryear]{biblatex}
 %%% or

--- a/Theses/MScThesis.tex
+++ b/Theses/MScThesis.tex
@@ -10,7 +10,7 @@
 \usepackage[style=ieee, sorting=none]{biblatex}
 %%% If you want to use "author-year" style
 %%% where `\cite{Foo2011}` generates "Foo et al. (2011)"
-%%% and   `\parentcite{Foo2011}` generates "(Foo et al. 2011)"
+%%% and   `\parencite{Foo2011}` generates "(Foo et al. 2011)"
 %%% then comment the line above and use
 %\usepackage[style=authoryear]{biblatex}
 %%% or


### PR DESCRIPTION
Just fixed the typo from \parentcite to \parencite